### PR TITLE
fix: useQuery to refetch data

### DIFF
--- a/backend/src/routes/testResource.route.ts
+++ b/backend/src/routes/testResource.route.ts
@@ -221,6 +221,7 @@ TestResourceRoute.patch(
     const testResourceUpdated = await db
       .update(TestResourceTable)
       .set({
+        title: body.title,
         content: body.content,
         description: body.description,
         updatedAt: dayjs().toISOString(),

--- a/frontend/app/test-management/ur-editor/resource/page.js
+++ b/frontend/app/test-management/ur-editor/resource/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Fragment, useCallback } from "react";
+import { useState, useEffect, Fragment } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,7 +9,7 @@ import { LoaderCircle } from "lucide-react";
 import MonacoEditor from "@/components/MonacoEditor";
 import { TestResourceApi } from "@/lib/api";
 import { useForm } from "react-hook-form";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ChatPanel from "@/components/ChatPanel";
 
 export default function NewResourcePage() {
@@ -18,12 +18,13 @@ export default function NewResourcePage() {
   const resourceId = searchParams.get("resourceId");
   const slug = searchParams.get("slug");
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const [scriptContent, setScriptContent] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [editorHeight, setEditorHeight] = useState("calc(100vh - 260px)");
 
-  const { data: resourceDetail } = useQuery({
+  const { data: resourceDetail, refetch } = useQuery({
     queryKey: ["detail-test-resource" + resourceId],
     queryFn: () => {
       return TestResourceApi().get(resourceId, { projectId });
@@ -34,12 +35,28 @@ export default function NewResourcePage() {
   const { register, getValues, setValue } = useForm();
 
   useEffect(() => {
+    if (localStorage.getItem("resource_updated") === "true" && resourceId) {
+      localStorage.removeItem("resource_updated");
+
+      queryClient.invalidateQueries(["detail-test-resource" + resourceId]);
+      queryClient.invalidateQueries(["test-resource", projectId]);
+
+      refetch();
+    }
+  }, [resourceId, projectId, queryClient, refetch]);
+
+  useEffect(() => {
     if (resourceDetail?.testResource && resourceId) {
       setValue("title", resourceDetail.testResource.title);
       setValue("description", resourceDetail.testResource.description);
       setScriptContent(resourceDetail.testResource.content);
     }
   }, [resourceDetail, resourceId, setValue]);
+
+  const invalidateCaches = async () => {
+    await queryClient.invalidateQueries(["detail-test-resource" + resourceId]);
+    await queryClient.invalidateQueries(["test-resource", projectId]);
+  };
 
   const handleEdit = async () => {
     const data = getValues();
@@ -58,6 +75,9 @@ export default function NewResourcePage() {
         content: scriptContent,
         projectId,
       });
+
+      await invalidateCaches();
+      localStorage.setItem("resource_updated", "true");
 
       toast.success("Resource edited successfully");
       router.push(`/test-management?projectId=${projectId}`);
@@ -89,6 +109,9 @@ export default function NewResourcePage() {
         content: scriptContent,
         projectId,
       });
+
+      await queryClient.invalidateQueries(["test-resource", projectId]);
+      localStorage.setItem("resource_updated", "true");
 
       toast.success("Resource created successfully");
       router.push(`/test-management?projectId=${projectId}`);

--- a/frontend/components/test-management/TestResource.jsx
+++ b/frontend/components/test-management/TestResource.jsx
@@ -29,6 +29,8 @@ export default function TestRoute({ project = {} }) {
     queryFn: () => {
       return TestResourceApi().list({ projectId: project.id });
     },
+    refetchOnMount: true,
+    cacheTime: 0,
   });
 
   useEffect(() => {
@@ -38,6 +40,13 @@ export default function TestRoute({ project = {} }) {
       setListTestResource(data.listTestResource.slice(startIndex, endIndex));
     }
   }, [data, page]);
+
+  useEffect(() => {
+    if (localStorage.getItem("resource_updated") === "true" && project.id) {
+      localStorage.removeItem("resource_updated");
+      refetch();
+    }
+  }, [project.id, refetch]);
 
   return (
     <Card className="overflow-hidden border rounded-lg shadow-sm">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed test resource pages so they always show the latest data after edits or creation by refetching with useQuery and clearing caches. This prevents stale information from appearing in the UI.

<!-- End of auto-generated description by mrge. -->

